### PR TITLE
Fix zscore docstring

### DIFF
--- a/simple/funcs.py
+++ b/simple/funcs.py
@@ -361,7 +361,7 @@ def zscore(X: NDArray, period: int) -> NDArray[np.float64]:
 
     Parameters:
     X (numpy.ndarray): Input array.
-    window (int): Window size.
+    period (int): Rolling window size.
 
     Returns:
     numpy.ndarray: Array with the rolling Z-scores.


### PR DESCRIPTION
## Summary
- clarify parameter name in the zscore docstring

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement numpy)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68404766aa8883208aaec06ffa7941b8